### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -5,6 +5,9 @@ name: SonarQube Analysis
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-123028/Battleship2/security/code-scanning/5](https://github.com/IGE-123028/Battleship2/security/code-scanning/5)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix (without changing behavior): define workflow-level permissions with `contents: read`, which is sufficient for `actions/checkout` and this Sonar analysis flow.

Change location: `.github/workflows/sonar.yml`, near the top-level keys (after `on:` and before `jobs:`).  
No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
