### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qodana-123028.yml
+++ b/.github/workflows/qodana-123028.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   qodana:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-123028/Battleship2/security/code-scanning/4](https://github.com/IGE-123028/Battleship2/security/code-scanning/4)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best single fix here (without changing intended functionality): add workflow-level permissions with `contents: read`, which is the minimal scope CodeQL suggests and is sufficient for checkout and analysis reads in this snippet.

Change region: `.github/workflows/qodana-123028.yml`, near the top-level keys (`name`, `on`, `jobs`).  
No imports, methods, or dependencies are needed—just YAML key insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
