### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qodana-123023.yml
+++ b/.github/workflows/qodana-123023.yml
@@ -1,6 +1,9 @@
 # IGE-123023 - Rodrigo Sampaio
 name: Qodana Long Method Check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-123028/Battleship2/security/code-scanning/3](https://github.com/IGE-123028/Battleship2/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define workflow-level permissions with `contents: read` (sufficient for checkout and analysis in this snippet). This preserves existing behavior while making access explicit and stable across org/repo setting changes.

Change location:
- File: `.github/workflows/qodana-123023.yml`
- Insert `permissions:` near the top-level (after `name` is ideal), before `on:`.

No imports, methods, or external definitions are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
