### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+
 # Disabled as an automatic workflow because Complete CI/CD Pipeline now runs
 # the Maven dependency check, compile, tests, and documentation generation.
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-123028/Battleship2/security/code-scanning/2](https://github.com/IGE-123028/Battleship2/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here (without changing functionality): define workflow-level permissions with `contents: read`, since this single job only checks out code and runs Maven commands.

**Where to change:** `.github/workflows/maven.yml`, directly under `name:` (before `on:`), add:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are needed—this is a YAML configuration-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
