### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,9 @@ on:
   #      - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IGE-123028/Battleship2/security/code-scanning/1](https://github.com/IGE-123028/Battleship2/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (or job) defining least privilege.  
Best fix here: add at the workflow root (after `on:` block, before `jobs:`) with:

- `contents: read`

This preserves current functionality (`actions/checkout` can still read repository contents) while preventing unintended broader token access inherited from defaults.

File to change: `.github/workflows/docker-publish.yml`  
Region: between `on:` and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
